### PR TITLE
Fix branch name existence check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
             git checkout ${{ inputs.new_branch_ref }}
         fi
         
-        if [ -n $(git branch --remotes --list 'origin/${{ inputs.new_branch_name }}') ]; then
+        if [ ! -z $(git branch --remotes --list 'origin/${{ inputs.new_branch_name }}') ]; then
             echo "Error: The branch name ${{ inputs.new_branch_name }} is already used."
             exit 1
         fi


### PR DESCRIPTION
I don't know what exactly happens,

`test -n $(git branch --remotes --list '<BRANCH_NAME>')` does not work for me but `test ! -z $(git branch --remotes --list '<BRANCH_NAME>')` works.

Thank you.