### PR TITLE
Feature: add field to allow gracefully handling if branch exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Field | Mandatory | Observation
 **new_branch_name** | YES | New branch name created on other repository <br/> _e.g: `release-*.*.*`_
 **new_branch_ref** | NO | Reference to create the new branch name on other repository <br/> _e.g: `release-candidate` (the `default branch` is used if not informed)_
 **access_token** | NO | A [PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) that has access to the repository (if necessary).
+**ignore_branch_exists** | NO | This (boolean) field will gracefully skip branch creation if the requested branch already exists <br/> _e.g: `true`_
 
 * * *
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,9 @@ inputs:
     access_token:
         description: 'A PAT that has access to the repository (if necessary)'
         required: false
-
+    ignore_branch_exists:
+        description: 'If the branch already exists then do not attempt to create branch'
+        required: false
 runs:
   using: "composite"
   steps:
@@ -46,7 +48,12 @@ runs:
             git fetch -a
             git checkout ${{ inputs.new_branch_ref }}
         fi
-        
+
+        if ${{ inputs.ignore_branch_exists }} && [ ! -z $(git branch --remotes --list 'origin/${{ inputs.new_branch_name }}') ]; then
+            echo "[INFO] Branch ${{ inputs.new_branch_ref }} already exists. Skipping branch creation"
+            exit 0
+        fi
+
         if [ ! -z $(git branch --remotes --list 'origin/${{ inputs.new_branch_name }}') ]; then
             echo "Error: The branch name ${{ inputs.new_branch_name }} is already used."
             exit 1


### PR DESCRIPTION
This PR introduces a new field called `ignore_branch_exists`. When this field is set to true and the requested branch already exists, it will gracefully exit the action step allowing for further steps to continue. 

When `ignore_branch_exists` is omitted or set to false, the default behavior will take place, which is to `exit 1` informing the user that the branch exists.

resolves #4 