### PR TITLE
Feature: SSH Deploy Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Field | Mandatory | Observation
 **repository_name** | YES | Repository Name <br/> _e.g: `my-repo-name`_
 **new_branch_name** | YES | New branch name created on other repository <br/> _e.g: `release-*.*.*`_
 **new_branch_ref** | NO | Reference to create the new branch name on other repository <br/> _e.g: `release-candidate` (the `default branch` is used if not informed)_
-**access_token** | NO | A [PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) that has access to the repository (if necessary).
+**access_token** | NO | A [PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) that has access to the repository (if necessary). Note: this should not be combined with `ssh_deploy_key`. 
 **ignore_branch_exists** | NO | This (boolean) field will gracefully skip branch creation if the requested branch already exists <br/> _e.g: `true`_
+**ssh_deploy_key** | NO | A [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys) that has been configured to allow access from the source to destination repository. (if necessary) Note: this should not be combined with `access_token`. 
 
 * * *
 

--- a/action.yml
+++ b/action.yml
@@ -16,10 +16,13 @@ inputs:
         description: 'Ref to create the new branch name on other repository (e.g: main)'
         required: false
     access_token:
-        description: 'A PAT that has access to the repository (if necessary)'
+        description: 'A PAT that has access to the repository (if necessary). Not to be combined with ssh_deploy_key'
         required: false
     ignore_branch_exists:
         description: 'If the branch already exists then do not attempt to create branch'
+        required: false
+    ssh_deploy_key:
+        description: 'Allows cloning of git reposorties via SSH Key. Not to be combined with access_token'
         required: false
 runs:
   using: "composite"
@@ -27,11 +30,30 @@ runs:
 
     - name: Clone informed repository
       run: |
-        if [ -z "${{ inputs.access_token }}" ]; then
-            git clone https://github.com/${{ inputs.repository_owner }}/${{ inputs.repository_name }}.git
-        else
-            git clone https://${{ inputs.access_token }}@github.com/${{ inputs.repository_owner }}/${{ inputs.repository_name }}.git
+        # If access_token and ssh_deploy_key are defined then error out.
+        if [ ! -z "${{ inputs.access_token }}" ] && [ ! -z "${{ inputs.ssh_deploy_key }}" ]; then
+            echo "Error: access_token and ssh_deploy_key are defined. Please only use one."
+            exit 1
         fi
+
+        if [ ! -z "${{ inputs.access_token }}" ]; then
+            git clone https://${{ inputs.access_token }}@github.com/${{ inputs.repository_owner }}/${{ inputs.repository_name }}.git
+        elif [ ! -z "${{ inputs.ssh_deploy_key }}" ]; then
+            mkdir --parents "$HOME/.ssh"
+
+            DEPLOY_KEY_FILE="$HOME/.ssh/deploy_key"
+            echo "${{ inputs.ssh_deploy_key }}" > "$DEPLOY_KEY_FILE"
+            chmod 600 "$DEPLOY_KEY_FILE"
+
+            SSH_KNOWN_HOSTS_FILE="$HOME/.ssh/known_hosts"
+            ssh-keyscan -H "github.com" > "$SSH_KNOWN_HOSTS_FILE"
+            
+            export GIT_SSH_COMMAND="ssh -i "$DEPLOY_KEY_FILE" -o UserKnownHostsFile=$SSH_KNOWN_HOSTS_FILE"
+            git clone git@github.com:${{ inputs.repository_owner }}/${{ inputs.repository_name }}.git
+        else
+            git clone https://github.com/${{ inputs.repository_owner }}/${{ inputs.repository_name }}.git
+        fi
+
         if [ -d "${{ inputs.repository_name }}" ]; then
             echo "Cloned ${{ inputs.repository_name }} repository successfully."
         else


### PR DESCRIPTION
This PR will introduce a field called `ssh_deploy_key`. We can use this instead of a PAT in order to connect the GHA to the destination repository.

The behavior will be as follows:
- If access_token and ssh_deploy_key are defined: error
- if access_token is set: clone with access token
- if ssh_deploy_key is set: clone using ssh key
- if neither acces_token or ssh_deploy_key are set: do a basic clone


resolves #6 