### PR TITLE
Add options to specify user and email in git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Field | Mandatory | Observation
 **access_token** | NO | A [PAT](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) that has access to the repository (if necessary). Note: this should not be combined with `ssh_deploy_key`. 
 **ignore_branch_exists** | NO | This (boolean) field will gracefully skip branch creation if the requested branch already exists <br/> _e.g: `true`_
 **ssh_deploy_key** | NO | A [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys) that has been configured to allow access from the source to destination repository. (if necessary) Note: this should not be combined with `access_token`. 
-
+**git_user_name** | NO | Specify the user.name to set in the git config
+**git_user_email** | NO | Specify the user.email to set in the git config
 * * *
 
 ## 🤝 Contributing

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,14 @@ inputs:
     ssh_deploy_key:
         description: 'Allows cloning of git reposorties via SSH Key. Not to be combined with access_token'
         required: false
+    git_user_name:
+        description: 'Allows setting user.name in git config'
+        required: false
+        default: github-actions
+    git_user_email:
+        description: 'Allows setting user.email in git config'
+        required: false
+        default: github-actions@github.com
 runs:
   using: "composite"
   steps:
@@ -81,8 +89,8 @@ runs:
             exit 1
         fi
         git checkout -b ${{ inputs.new_branch_name }}
-        git config user.name github-actions
-        git config user.email github-actions@github.com
+        git config user.name ${{ inputs.git_user_name }}
+        git config user.email ${{ inputs.git_user_email }}
         git push origin ${{ inputs.new_branch_name }}
       shell: bash
 


### PR DESCRIPTION
This PR introduces optional arguments to specify the git.user.name and git.user.email in the git config.
Previously it was hard coded to `github-actions` and `github-actions@github.com` respectively. This is useful when you want to use the ssh deploy key where the public key is under a different email.

 `github-actions` and `github-actions@github.com` are kept as default if not specified

I tried submitting a corresponding issue but it wouldn't let me.

Let me know what you think!